### PR TITLE
Use URL search parameters to save queries and use FP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@mobily/ts-belt": "^3.13.1",
         "@radix-ui/react-alert-dialog": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.2.3",
         "@radix-ui/react-dialog": "^1.1.11",
@@ -1803,6 +1804,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mobily/ts-belt": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.*"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@mobily/ts-belt": "^3.13.1",
     "@radix-ui/react-alert-dialog": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.2.3",
     "@radix-ui/react-dialog": "^1.1.11",

--- a/src/app/_components/tracks/hooks/useQueryParams.ts
+++ b/src/app/_components/tracks/hooks/useQueryParams.ts
@@ -1,0 +1,34 @@
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+import * as Belt from "@mobily/ts-belt";
+
+const useQueryParams = <Params extends readonly string[]>(paramsList: Params) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const params: Record<Params[number], Belt.Option<string>> =
+    Object.fromEntries(
+      paramsList.map((param) => [param, Belt.O.fromNullable(searchParams.get(param))])
+    ) as Record<Params[number], Belt.Option<string>>;
+
+  const createQueryString = useCallback(
+    (name: Params[number], value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set(name, value);
+
+      return params.toString();
+    },
+    [searchParams]
+  );
+
+  const setParam = useCallback(
+    (name: Params[number], value: string) => {
+      router.push(`${pathname}?${createQueryString(name, value)}`);
+    },
+    [pathname, createQueryString, router]
+  );
+
+  return { setParam, params };
+};
+
+export default useQueryParams;

--- a/src/app/_components/tracks/hooks/useTracksQueryParams.ts
+++ b/src/app/_components/tracks/hooks/useTracksQueryParams.ts
@@ -1,0 +1,63 @@
+import useQueryParams from "./useQueryParams";
+import * as Belt from "@mobily/ts-belt";
+
+const queryParams = ["page", "limit", "sort", "order", "search", "genre"] as const;
+const sortOptions = ["title", "artist", "album", "createdAt"] as const;
+const orderOptions = ["asc", "desc"] as const;
+type SortParameter = (typeof sortOptions)[number];
+type OrderParameter = (typeof orderOptions)[number];
+
+const paramDefaults = {
+    page: 1,
+    limit: 10,
+    sort: "createdAt" as SortParameter,
+    order: "desc" as OrderParameter,
+    search: "",
+    genre: "All"
+}
+
+const isSortParameter = (param: string): param is SortParameter => {
+    return sortOptions.includes(param as SortParameter);
+}
+
+const isOrderParameter = (param: string): param is OrderParameter => {
+    return orderOptions.includes(param as OrderParameter);
+}
+
+const useTracksQueryParams = () => {
+    const { setParam, params } = useQueryParams(queryParams);
+
+    const page = Belt.pipe(
+        params.page,
+        Belt.O.flatMap((p) => !isNaN(Number(p)) ? Belt.O.Some(Number(p)) : Belt.O.None),
+        Belt.O.getWithDefault(paramDefaults.page),
+    );
+    const limit = Belt.pipe(
+        params.limit,
+        Belt.O.flatMap((p) => !isNaN(Number(p)) ? Belt.O.Some(p) : Belt.O.None),
+        Belt.O.map((p) => Number(p)),
+        Belt.O.getWithDefault(paramDefaults.limit)
+    );
+    const sort = Belt.pipe(
+        params.sort,
+        Belt.O.flatMap((p) => isSortParameter(p) ? Belt.O.Some(p) : Belt.O.None),
+        Belt.O.getWithDefault(paramDefaults.sort)
+    );
+    const order = Belt.pipe(
+        params.order,
+        Belt.O.flatMap((p) => isOrderParameter(p) ? Belt.O.Some(p) : Belt.O.None),
+        Belt.O.getWithDefault(paramDefaults.order)
+    );
+    const search = Belt.pipe(
+        params.search,
+        Belt.O.getWithDefault(paramDefaults.search)
+    );
+    const genre = Belt.pipe(
+        params.genre,
+        Belt.O.getWithDefault(paramDefaults.genre)
+    );
+
+    return { setParam, page, limit, sort, order, search, genre };
+};
+
+export default useTracksQueryParams;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "noUncheckedIndexedAccess": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Created `useQueryParams` hook to allow saving query parameters in URL.
Created `useTracksQueryParams` hook that validates query parameters using `ts-belt`.